### PR TITLE
Enhance DOI handling for biomed-central.csl

### DIFF
--- a/biomed-central.csl
+++ b/biomed-central.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US" page-range-format="minimal">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="minimal" default-locale="en-US">
   <info>
     <title>BioMed Central</title>
     <id>http://www.zotero.org/styles/biomed-central</id>

--- a/biomed-central.csl
+++ b/biomed-central.csl
@@ -15,10 +15,13 @@
     <contributor>
       <name>Patrick O'Brien</name>
     </contributor>
+    <contributor>
+      <name>Nour Edin Darwish</name>
+    </contributor>
     <category citation-format="numeric"/>
     <category field="medicine"/>
     <category field="biology"/>
-    <updated>2021-11-02T17:11:28+00:00</updated>
+    <updated>2025-05-01T18:48:57+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -90,11 +93,14 @@
   </macro>
   <macro name="access">
     <choose>
-      <if type="article-journal">
+      <if variable="DOI">
         <choose>
-          <if match="none" variable="page volume">
-            <text variable="DOI" prefix="https://doi.org/"/>
+          <if type="dataset">
+            <text variable="DOI" prefix="http://dx.doi.org/"/>
           </if>
+          <else>
+            <text variable="DOI" prefix="doi:"/>
+          </else>
         </choose>
       </if>
       <else-if type="webpage post-weblog post" match="any">


### PR DESCRIPTION
Update DOI handling for improved citation practices:
- Always show DOIs for references using the doi: prefix format (The previous implementation only showed DOIs when page/volume weren't available, which wasn't explicitly required by BMC. Showing DOIs consistently for all references improves citation quality and scholarly discoverability, while still conforming to BMC's formatting requirements)
- Add special handling for dataset DOIs using http://dx.doi.org/ format as shown in examples

Based on BMC's guidelines at:
https://bmcbioinformatics.biomedcentral.com/submission-guidelines/preparing-your-manuscript/research-article